### PR TITLE
Update and rename 2019-02-15-install.md to 2020-07-19-install.md

### DIFF
--- a/_posts/2020-07-19-install.md
+++ b/_posts/2020-07-19-install.md
@@ -697,6 +697,16 @@ In addition, we'll generate a set of 4096-bit diffie-hellman parameters to impro
 sudo mkdir -p /etc/nginx/ssl
 sudo openssl dhparam -out /etc/nginx/ssl/dhp-4096.pem 4096
 ```
+If you are using a custom generated CA, in order to load correctly the presentations, we have to edit the value of NODE_EXTRA_CA_CERTS with our root custom certificate.
+To make it working at every bbb restart we can add the following line in the file `/usr/share/meteor/bundle/systemd_start.sh`
+
+<pre><code>
+<span style="color:#980000;font-weight:bold">export NODE_EXTRA_CA_CERTS='/etc/ssl/certs/[myrootcert].pem'</span>
+cd /usr/share/meteor/bundle
+export ROOT_URL=http://127.0.0.1/html5client
+export MONGO_OPLOG_URL=mongodb://127.0.1.1/local
+...
+</code></pre>
 
 Now we can edit the nginx configuration to use SSL. Edit the file `/etc/nginx/sites-available/bigbluebutton` to add the marked lines. Ensure that you're using the correct filenames to match the certificate and key files you created above.
 


### PR DESCRIPTION
Added the env var NODE_EXTRA_CA_CERTS to make the presentations work in case of custom CA (not included in the usual Mozilla CA)
E.g.
NODE_EXTRA_CA_CERTS='/etc/ssl/certs/[myrootcert].pem'